### PR TITLE
Simplify threading

### DIFF
--- a/Tests/WebSocketTests/WebSocketTests.swift
+++ b/Tests/WebSocketTests/WebSocketTests.swift
@@ -221,20 +221,6 @@ private extension WebSocketTests {
         let client = WebSocket(url: url(port))
         try withExtendedLifetime((server, client)) { server.listen(); try block(server, client) }
     }
-
-    func withDelayServer(
-        delay: TimeInterval,
-        _ block: (WebSocketServer, WebSocket) throws -> Void
-    ) throws {
-        let port = ports.removeFirst()
-        let provider: (String) -> String? = { (input) -> String? in
-            Thread.sleep(forTimeInterval: delay)
-            return input
-        }
-        let server = WebSocketServer(port: port, replyProvider: .matchReply(provider))
-        let client = WebSocket(url: url(port))
-        try withExtendedLifetime((server, client)) { server.listen(); try block(server, client) }
-    }
 }
 
 private extension WebSocketTests {
@@ -282,7 +268,6 @@ private extension WebSocketTests {
     func expectNoError() -> (Error?) -> Void {
         let expectation = self.expectation(description: "Should not have had an error")
         return { error in
-            print(#function)
             XCTAssertNil(error)
             expectation.fulfill()
         }

--- a/Tests/WebSocketTests/WebSocketTests.swift
+++ b/Tests/WebSocketTests/WebSocketTests.swift
@@ -212,8 +212,8 @@ private extension WebSocketTests {
 
     func withReplyServer(
         _ replies: Array<String?>,
-        _ block: (WebSocketServer, WebSocket
-        ) throws -> Void) throws {
+        _ block: (WebSocketServer, WebSocket) throws -> Void
+    ) throws {
         let port = ports.removeFirst()
         var replies = replies
         let provider: () -> String? = { return replies.removeFirst() }

--- a/Tests/WebSocketTests/WebSocketTests.swift
+++ b/Tests/WebSocketTests/WebSocketTests.swift
@@ -153,6 +153,46 @@ class WebSocketTests: XCTestCase {
             waitForExpectations(timeout: 2)
         }
     }
+
+    func testCanSendFromTwoThreadsSimultaneously() throws {
+        let queueCount = 8
+        let queues = (0..<queueCount).map { DispatchQueue(label: "\($0)") }
+
+        let messageCount = 100
+        let sendMessages: (WebSocket) -> Void = { client in
+            (0..<messageCount).forEach { messageIndex in
+                (0..<queueCount).forEach { queueIndex in
+                    queues[queueIndex].async { client.send("\(queueIndex)-\(messageIndex)") }
+                }
+            }
+        }
+
+        let receiveMessageEx = expectation(
+            description: "Should have received \(queueCount * messageCount) messages"
+        )
+        receiveMessageEx.expectedFulfillmentCount = queueCount * messageCount
+
+        try withEchoServer { (server, client) in
+            let sub = client.sink(
+                receiveCompletion: {_ in },
+                receiveValue: { message in
+                    switch message {
+                    case .success(.open):
+                        sendMessages(client)
+                    case .success(.text):
+                        receiveMessageEx.fulfill()
+                    default:
+                        XCTFail()
+                    }
+                }
+            )
+            defer { sub.cancel() }
+
+            client.connect()
+            waitForExpectations(timeout: 10)
+            client.close()
+        }
+    }
 }
 
 private extension WebSocketTests {
@@ -170,11 +210,28 @@ private extension WebSocketTests {
         try withExtendedLifetime((server, client)) { server.listen(); try block(server, client) }
     }
 
-    func withReplyServer(_ replies: Array<String?>, _ block: (WebSocketServer, WebSocket) throws -> Void) throws {
+    func withReplyServer(
+        _ replies: Array<String?>,
+        _ block: (WebSocketServer, WebSocket
+        ) throws -> Void) throws {
         let port = ports.removeFirst()
         var replies = replies
         let provider: () -> String? = { return replies.removeFirst() }
         let server = WebSocketServer(port: port, replyProvider: .reply(provider))
+        let client = WebSocket(url: url(port))
+        try withExtendedLifetime((server, client)) { server.listen(); try block(server, client) }
+    }
+
+    func withDelayServer(
+        delay: TimeInterval,
+        _ block: (WebSocketServer, WebSocket) throws -> Void
+    ) throws {
+        let port = ports.removeFirst()
+        let provider: (String) -> String? = { (input) -> String? in
+            Thread.sleep(forTimeInterval: delay)
+            return input
+        }
+        let server = WebSocketServer(port: port, replyProvider: .matchReply(provider))
         let client = WebSocket(url: url(port))
         try withExtendedLifetime((server, client)) { server.listen(); try block(server, client) }
     }
@@ -225,6 +282,7 @@ private extension WebSocketTests {
     func expectNoError() -> (Error?) -> Void {
         let expectation = self.expectation(description: "Should not have had an error")
         return { error in
+            print(#function)
             XCTAssertNil(error)
             expectation.fulfill()
         }


### PR DESCRIPTION
- [x] Remove `webSocketQueue` because `URLSessionWebSocketTask` seems to be thread-safe
- [x] Allow consumers to specify the `DispatchQueue` on which `WebSocket` will publish messages