### PR TITLE
Add comprehensive logging

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "8a865bd15e69526cbdfcfd7c47698eb20b2ba951",
-          "version": "2.19.0"
+          "revision": "43931b7a7daf8120a487601530c8bc03ce711992",
+          "version": "2.25.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/shareup/websocket-protocol.git",
         "state": {
           "branch": null,
-          "revision": "e3cc3105c75d070e0e6cd82568036b67a103ff5a",
-          "version": "2.2.0"
+          "revision": "bd6257e3c4b23484dfc73c550b025f96c8e151f6",
+          "version": "2.3.1"
         }
       }
     ]

--- a/Sources/WebSocket/OSLog+WebSocket.swift
+++ b/Sources/WebSocket/OSLog+WebSocket.swift
@@ -1,0 +1,9 @@
+import Foundation
+import os.log
+
+extension OSLog {
+    private static var subsystem =
+        Bundle.main.bundleIdentifier ?? "app.shareup.websocket-apple"
+
+    static let webSocket = OSLog(subsystem: subsystem, category: "websocket")
+}

--- a/Sources/WebSocket/URLSessionWebSocketTaskMessage+WebSocket.swift
+++ b/Sources/WebSocket/URLSessionWebSocketTaskMessage+WebSocket.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension URLSessionWebSocketTask.Message: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case let .string(text):
+            return text
+        case let .data(data):
+            return "\(data.count) bytes"
+        @unknown default:
+            assertionFailure("Unsupported message: \(self)")
+            return "<unknown>"
+        }
+    }
+}

--- a/Sources/WebSocket/WebSocketMessage+URLSessionWebSocketTask.swift
+++ b/Sources/WebSocket/WebSocketMessage+URLSessionWebSocketTask.swift
@@ -14,3 +14,14 @@ extension WebSocketMessage {
         }
     }
 }
+
+extension Result: CustomDebugStringConvertible where Success == WebSocketMessage {
+    public var debugDescription: String {
+        switch self {
+        case let .success(message):
+            return message.debugDescription
+        case let .failure(error):
+            return error.localizedDescription
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds comprehensive logging using Apple's [`os_log`](https://developer.apple.com/documentation/os/logging). Currently, all the logs are captured at the `debug` log level, which means they are not persisted to disk. We may want to revisit this in the future, especially for things that could cause errors.

[WWDC video](https://developer.apple.com/videos/play/wwdc2016/721/)