### PR TITLE
Make the socket subject never fail

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,21 +11,12 @@
         }
       },
       {
-        "package": "Synchronized",
+        "package": "synchronized",
         "repositoryURL": "https://github.com/shareup/synchronized.git",
         "state": {
           "branch": null,
           "revision": "f01e4a1ee5fbf586d612a8dc0bc068603f6b9450",
           "version": "3.0.0"
-        }
-      },
-      {
-        "package": "WebSocketProtocol",
-        "repositoryURL": "https://github.com/shareup/websocket-protocol.git",
-        "state": {
-          "branch": null,
-          "revision": "bd6257e3c4b23484dfc73c550b025f96c8e151f6",
-          "version": "2.3.1"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "swift-log",
+        "repositoryURL": "https://github.com/apple/swift-log.git",
+        "state": {
+          "branch": null,
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
@@ -11,7 +20,7 @@
         }
       },
       {
-        "package": "synchronized",
+        "package": "Synchronized",
         "repositoryURL": "https://github.com/shareup/synchronized.git",
         "state": {
           "branch": null,

--- a/Package.swift
+++ b/Package.swift
@@ -10,23 +10,23 @@ let package = Package(
         .library(
             name: "WebSocket",
             targets: ["WebSocket"]
-        )],
+        ),
+            .library(
+                name: "WebSocketProtocol",
+                targets: ["WebSocketProtocol"])
+    ],
     dependencies: [
         .package(
             name: "Synchronized",
             url: "https://github.com/shareup/synchronized.git",
             from: "3.0.0"
         ),
-        .package(
-            name: "WebSocketProtocol",
-            url: "https://github.com/shareup/websocket-protocol.git",
-            from: "2.2.0"
-        ),
         .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0")],
     targets: [
         .target(
             name: "WebSocket",
             dependencies: ["Synchronized", "WebSocketProtocol"]),
+        .target(name: "WebSocketProtocol"),
         .testTarget(
             name: "WebSocketTests",
             dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -21,11 +21,14 @@ let package = Package(
             url: "https://github.com/shareup/synchronized.git",
             from: "3.0.0"
         ),
-        .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0")],
+        .package(name: "swift-nio", url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0")
+    ],
+
     targets: [
         .target(
             name: "WebSocket",
-            dependencies: ["Synchronized", "WebSocketProtocol"]),
+            dependencies: ["Synchronized", "WebSocketProtocol", .product(name: "Logging", package: "swift-log")]),
         .target(name: "WebSocketProtocol"),
         .testTarget(
             name: "WebSocketTests",

--- a/Sources/WebSocket/OSLog+WebSocket.swift
+++ b/Sources/WebSocket/OSLog+WebSocket.swift
@@ -1,9 +1,0 @@
-import Foundation
-import os.log
-
-extension OSLog {
-    private static var subsystem =
-        Bundle.main.bundleIdentifier ?? "app.shareup.websocket-apple"
-
-    static let webSocket = OSLog(subsystem: subsystem, category: "websocket")
-}

--- a/Sources/WebSocket/WebSocket.swift
+++ b/Sources/WebSocket/WebSocket.swift
@@ -57,7 +57,7 @@ public final class WebSocket: WebSocketProtocol {
     private let lock = RecursiveLock()
     private func sync<T>(_ block: () throws -> T) rethrows -> T { try lock.locked(block) }
 
-    var url: URL?
+    public var url: URL?
 
     private let timeoutIntervalForRequest: TimeInterval
     private let timeoutIntervalForResource: TimeInterval

--- a/Sources/WebSocket/WebSocketError.swift
+++ b/Sources/WebSocket/WebSocketError.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum WebSocketError: Error {
     case invalidURL(URL)
+    case missingURL
     case invalidURLComponents(URLComponents)
     case notOpen
     case closed(URLSessionWebSocketTask.CloseCode, Data?)

--- a/Sources/WebSocketProtocol/WebSocketCloseCode.swift
+++ b/Sources/WebSocketProtocol/WebSocketCloseCode.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// A code indicating why a WebSocket connection closed.
+///
+/// Mirrors [URLSessionWebSocketTask](https://developer.apple.com/documentation/foundation/urlsessionwebsockettask/closecode).
+public enum WebSocketCloseCode: Int, CaseIterable {
+
+    /// A code that indicates the connection is still open.
+    case invalid = 0
+
+    /// A code that indicates normal connection closure.
+    case normalClosure = 1000
+
+    /// A code that indicates an endpoint is going away.
+    case goingAway = 1001
+
+    /// A code that indicates an endpoint terminated the connection due to a protocol error.
+    case protocolError = 1002
+
+    /// A code that indicates an endpoint terminated the connection after receiving a type of data it can’t accept.
+    case unsupportedData = 1003
+
+    /// A reserved code that indicates an endpoint expected a status code and didn’t receive one.
+    case noStatusReceived = 1005
+
+    /// A reserved code that indicates the connection closed without a close control frame.
+    case abnormalClosure = 1006
+
+    /// A code that indicates the server terminated the connection because it received data inconsistent with the message’s type.
+    case invalidFramePayloadData = 1007
+
+    /// A code that indicates an endpoint terminated the connection because it received a message that violates its policy.
+    case policyViolation = 1008
+
+    /// A code that indicates an endpoint is terminating the connection because it received a message too big for it to process.
+    case messageTooBig = 1009
+
+    /// A code that indicates the client terminated the connection because the server didn’t negotiate a required extension.
+    case mandatoryExtensionMissing = 1010
+
+    /// A code that indicates the server terminated the connection because it encountered an unexpected condition.
+    case internalServerError = 1011
+
+    /// A reserved code that indicates the connection closed due to the failure to perform a TLS handshake.
+    case tlsHandshakeFailure = 1015
+}

--- a/Sources/WebSocketProtocol/WebSocketMessage.swift
+++ b/Sources/WebSocketProtocol/WebSocketMessage.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// An enumeration of the types of messages that can be sent and received.
+public enum WebSocketMessage: CustomStringConvertible, CustomDebugStringConvertible, Hashable {
+    case open
+    case binary(Data)
+    case text(String)
+    case closed
+
+    public var description: String {
+        switch self {
+        case .open: return "open"
+        case .closed: return "closed"
+        case let .binary(data): return "\(data.count) bytes"
+        case let .text(text): return text
+        }
+    }
+
+    public var debugDescription: String { self.description }
+}
+

--- a/Sources/WebSocketProtocol/WebSocketProtocol.swift
+++ b/Sources/WebSocketProtocol/WebSocketProtocol.swift
@@ -1,0 +1,29 @@
+import Combine
+import Foundation
+
+public protocol WebSocketProtocol: Publisher where Failure == Never, Output == Result<WebSocketMessage, Error> {
+    /// The maximum number of bytes to buffer before the receive call fails with an error.
+    var maximumMessageSize: Int { get set }
+
+    /// Initializes an instance of `WebSocketProtocol` with the specified `URL`.
+    init(url: URL) throws
+
+    /// Connects the socket to the server.
+    func connect()
+
+    /// Sends the WebSocket data message, receiving the result in a completion handler.
+    func send(_ data: Data, completionHandler: @escaping (Error?) -> Void) throws
+
+    /// Sends the WebSocket text message, receiving the result in a completion handler.
+    func send(_ text: String, completionHandler: @escaping (Error?) -> Void) throws
+
+    /// Sends a close frame to the server with the given close code.
+    func close(_ closeCode: WebSocketCloseCode)
+}
+
+extension WebSocketProtocol {
+    /// Calls `WebSocketProtocol.close(closeCode: .goingAway)`.
+    public func close() {
+        self.close(.goingAway)
+    }
+}

--- a/Sources/WebSocketProtocol/WebSocketProtocol.swift
+++ b/Sources/WebSocketProtocol/WebSocketProtocol.swift
@@ -6,7 +6,7 @@ public protocol WebSocketProtocol: Publisher where Failure == Never, Output == R
     var maximumMessageSize: Int { get set }
 
     /// Initializes an instance of `WebSocketProtocol` with the specified `URL`.
-    init(url: URL) throws
+    init(url: URL?) throws
 
     /// Connects the socket to the server.
     func connect()


### PR DESCRIPTION
- Not sure if you are interested but here is very simple modification that makes the subject never fail, I am not sure if there is a more elegant way to do this? Perhaps we can check based on the type of error ?

Background ->

The application I am working with frequently deals with a socket that will timeout and close, I need to be able to call connect o n the existing socket without re-creating it and resubscribing all over the place. 

---

Other notes, I moved the protocol inside the main package, unless you are creating other web sockets from this same protocol it seems a bit overkill to have it as a completely separate package. 