### PR TITLE
'Publisher' is only available in watchOS 6.0 or newer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "WebSocket",
     platforms: [
-        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v5),
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6),
     ],
     products: [
         .library(


### PR DESCRIPTION
Dependencies
https://github.com/shareup/websocket-protocol/pull/4

<img width="1064" alt="Screen Shot 2021-11-04 at 22 53 15" src="https://user-images.githubusercontent.com/31082311/140445056-eefa4247-a629-4920-9a08-0c0f0a5bd4e9.png">
